### PR TITLE
Scope self locally to prevent global contamination

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -9,7 +9,7 @@ module.exports = NodeHelper.create({
 	},
 	// Override socketNotificationReceived method.
 	socketNotificationReceived: function(notification, payload) {
-		self = this;
+		var self = this;
 		this.url = payload.apiBase+"/" + payload.endpoint + "?lat=" + payload.lat + "&lon="+ payload.lon;
         setInterval(function() {
 			self.getData(self)


### PR DESCRIPTION
It turned out the getData() of one of my other modules wasn't called anymore because we both use self to get the address of the getData() callback function. It turns out that, without ```var``` nodejs uses a globally scoped self and since your module was loaded later, it allways "won" the callBack function. Using ```var``` in both your and my module keeps the callbacks sane again.