### PR TITLE
Use homepage API, Get 2.5h forecast

### DIFF
--- a/MMM-rain-forecast.js
+++ b/MMM-rain-forecast.js
@@ -23,8 +23,8 @@ Module.register("MMM-rain-forecast",{
 		this.payload = false;
 		this.sendSocketNotification("RAIN_REQUEST", {
 			updateInterval: this.config.refreshInterval * 60 * 1000,
-            apiBase: "https://gpsgadget.buienradar.nl",
-            endpoint: "data/raintext",
+            apiBase: "https://graphdata.buienradar.nl",
+            endpoint: "forecast/json",
             lat: this.config.lat,
             lon: this.config.lon,
 		});
@@ -81,7 +81,7 @@ Module.register("MMM-rain-forecast",{
         // loop through the received data array raining[] normally 24 position 0 to 23
         var xAs=1;
         for (i=0;i<raining.length;i++){
-            xAs=(xAs==1?xAs=2:xAs+13);
+            xAs=Math.round(i*(300/(raining.length-1)));
             setPoints += ', L' + xAs + ',' + (100-raining[i]);
         }
         // End of th3 line make sure it drops to the bottom of the canvas to avoid silly fill
@@ -95,15 +95,16 @@ Module.register("MMM-rain-forecast",{
         svg+='<path class="first_set" style="fill:' + this.config.fillColour + '" d="' + setPoints + '"></path>';
         svg+='</g>';
         // Set the class for the grid
-        svg+='<use class="grid double" xlink:href="#xGrid" style=""></use><use class="grid double" xlink:href="#yGrid" style=""></use>';
+        svg+='<use class="grid double" xlink:href="#xGrid" style=""></use>';
+        svg+='<use class="grid double" xlink:href="#yGrid" style=""></use>';
         // Time labels
         svg+='<g class="labels x-labels">';
-        svg+='<text x="20" y="115"  fill="white">' + times[1] + '</text>';
-        svg+='<text x="73" y="115"  fill="white">' + times[5]+ '</text>';
-        svg+='<text x="126" y="115" fill="white">' + times[9]+ '</text>';
-        svg+='<text x="179" y="115" fill="white">' + times[13] + '</text>';
-        svg+='<text x="232" y="115" fill="white">' + times[17] + '</text>';
-        svg+='<text x="285" y="115" fill="white">' + times[21] + '</text>';
+        svg+='<text x="20"  y="115"  fill="white">' + times[0] + '</text>';
+        svg+='<text x="65"  y="115"  fill="white">' + times[6] + '</text>';
+        svg+='<text x="120" y="115" fill="white">'  + times[12]+ '</text>';
+        svg+='<text x="175" y="115" fill="white">'  + times[18] + '</text>';
+        svg+='<text x="230" y="115" fill="white">'  + times[24] + '</text>';
+        svg+='<text x="285" y="115" fill="white">'  + times[30] + '</text>';
         svg+='</g></svg>';
         return svg;
     },

--- a/MMM-rain-forecast.js
+++ b/MMM-rain-forecast.js
@@ -77,15 +77,14 @@ Module.register("MMM-rain-forecast",{
          * received value 77 = 100 - 38 = 72 on the canvas
          * M01,200 is the start
          */
-        var setPoints='M01,100';
+        var setPoints='M01 100 S';
         // loop through the received data array raining[] normally 24 position 0 to 23
-        var xAs=1;
         for (i=0;i<raining.length;i++){
             xAs=Math.round(i*(300/(raining.length-1)));
-            setPoints += ', L' + xAs + ',' + (100-raining[i]);
+            setPoints += xAs + ',' + (100-raining[i]) + ' ';
         }
         // End of th3 line make sure it drops to the bottom of the canvas to avoid silly fill
-        setPoints +=', L' + xAs + ',100 Z';
+        setPoints +='L' + xAs + ',100 Z';
         var svg='<svg class="graph" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">';
         //Set grid lines xAs ans yAs size is determined in CSS
         svg+='<g class="grid x-grid" id="xGrid"><line x1="1" x2="1" y1="00" y2="100"></line></g>';

--- a/node_helper.js
+++ b/node_helper.js
@@ -10,7 +10,7 @@ module.exports = NodeHelper.create({
 	// Override socketNotificationReceived method.
 	socketNotificationReceived: function(notification, payload) {
 		var self = this;
-		this.url = payload.apiBase+"/" + payload.endpoint + "?lat=" + payload.lat + "&lon="+ payload.lon;
+ 		this.url = payload.apiBase+"/" + payload.endpoint + "?lat=" + payload.lat + "&lon=" + payload.lon;
         setInterval(function() {
 			self.getData(self)
 		}, payload.updateInterval);
@@ -39,27 +39,26 @@ module.exports = NodeHelper.create({
 			});
 			return;
 		}
-        // This is test data just to see the graph if there is no rain
-        //body="077|10:05\n034|10:10\n101|10:15\n087|10:20\n077|10:25\n000|10:30\n000|10:35\n000|10:40\n077|10:45\n087|10:50\n087|10:55\n077|11:00\n077|11:05\n034|11:10\n017|11:15\n000|11:20\n000|11:25\n000|11:30\n000|11:35\n000|11:40\n000|11:45\n000|11:50\n000|11:55\n000|12:00";
+		// Test data
+        //body = '{"color":"#5A9BD3","lat":52.09,"lon":5.12,"borders":[{"title":"licht","lower":0,"upper":40},{"title":"matig","lower":40,"upper":70},{"title":"zwaar","lower":70,"upper":100}],"timeOffset":2.0,"radius":1,"forecasts":[{"datetime":"2019-05-09T09:50:00","utcdatetime":"2019-05-09T07:50:00","precipitation":1.0,"precipation":0.2,"original":20,"value":0},{"datetime":"2019-05-09T09:55:00","utcdatetime":"2019-05-09T07:55:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:00:00","utcdatetime":"2019-05-09T08:00:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:05:00","utcdatetime":"2019-05-09T08:05:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:10:00","utcdatetime":"2019-05-09T08:10:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:15:00","utcdatetime":"2019-05-09T08:15:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:20:00","utcdatetime":"2019-05-09T08:20:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:25:00","utcdatetime":"2019-05-09T08:25:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:30:00","utcdatetime":"2019-05-09T08:30:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:35:00","utcdatetime":"2019-05-09T08:35:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:40:00","utcdatetime":"2019-05-09T08:40:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:45:00","utcdatetime":"2019-05-09T08:45:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:50:00","utcdatetime":"2019-05-09T08:50:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T10:55:00","utcdatetime":"2019-05-09T08:55:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:00:00","utcdatetime":"2019-05-09T09:00:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:05:00","utcdatetime":"2019-05-09T09:05:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:10:00","utcdatetime":"2019-05-09T09:10:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:15:00","utcdatetime":"2019-05-09T09:15:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:20:00","utcdatetime":"2019-05-09T09:20:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:25:00","utcdatetime":"2019-05-09T09:25:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:30:00","utcdatetime":"2019-05-09T09:30:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:35:00","utcdatetime":"2019-05-09T09:35:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:40:00","utcdatetime":"2019-05-09T09:40:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:45:00","utcdatetime":"2019-05-09T09:45:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:50:00","utcdatetime":"2019-05-09T09:50:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T11:55:00","utcdatetime":"2019-05-09T09:55:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T12:00:00","utcdatetime":"2019-05-09T10:00:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T12:05:00","utcdatetime":"2019-05-09T10:05:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T12:10:00","utcdatetime":"2019-05-09T10:10:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T12:15:00","utcdatetime":"2019-05-09T10:15:00","precipitation":0.0,"precipation":0.0,"original":0,"value":0},{"datetime":"2019-05-09T12:20:00","utcdatetime":"2019-05-09T10:20:00","precipitation":0.2,"precipation":1.0,"original":20,"value":0}],"emptytext":"Geen neerslag verwacht","createdUtc":"2019-05-09T07:45:19.1334476Z","lastRefreshUtc":"2019-05-09T07:37:07","elapsedMs":0}';
 
         // Make an array with the amount of rain  077|10:05 = rain|time
         var rainDrops = [];
         // Make an array with the times received
-		var times = [];
+        var times = [];
         // Count all rain together
-		var expectRain = 0;
-        // Make seprate lines
-		var lines = body.split('\n');
-		for(var i = 0;i < lines.length-1;i++){
-			var values = lines[i].split('|');
-            // split rain from time
-            // rainDrops.push(values[0]=="NaN"?0:(Math.pow(10,(parseInt(values[0])-109)/32)) * 10);
-            // 29th April 2018 changed devide from 3 to 2.55 makes a better graph
-						// Devide the recieved value by 2.5 we can use less height maximum rain = 255 /2.55 = 100 graph height is 100
-			rainDrops.push(values[0]=="NaN"?0:parseInt(values[0])/2.55);
-            times.push(values[1]);
-			expectRain += parseInt(values[0]);
-		}
+        var expectRain = 0;
+        data = JSON.parse(body);
+        forecast = data.forecasts;
+        for (raindata in forecast) {
+            if (forecast.hasOwnProperty(raindata)) {
+                var rain = forecast[raindata].original;
+                var time = forecast[raindata].datetime.substring(11, 16);
+                expectRain += parseInt(rain);
+                rainDrops.push(rain);
+                times.push(time);
+            }
+        }
         // Send all to script
         self.sendSocketNotification('RAIN_DATA', {
             rainDrops:  rainDrops,


### PR DESCRIPTION
This PR changes the API to the internal buienradar homepage API, which serves json (easier to parse) but more important: 2,5h of forecast instead of 2 on the public API.

I made some design choices like using the "original" field instead of precipitation, because it contained ready-to-use numbers, but I don't know where they go for rain showers, might go off chart. Also, I don't parse the datetime field, but simply cut the time using substring.

The testdata is manipulated to show only peaks at exactly the start en end of graph, so that the svg creator can be tested for the edge cases.

Last: I'm not sure about the legality of using the homepage API...